### PR TITLE
Update AbstractXMLScriptlet.class.php

### DIFF
--- a/core/src/main/php/scriptlet/xml/workflow/AbstractXMLScriptlet.class.php
+++ b/core/src/main/php/scriptlet/xml/workflow/AbstractXMLScriptlet.class.php
@@ -143,16 +143,24 @@
       // Call state's process() method. In case it returns FALSE, the
       // context's insertStatus() method will not be called. This, for
       // example, is useful when process() wants to send a redirect.
+      $doRender = TRUE;
       if (FALSE === ($r= $request->state->process($request, $response, $context))) {
-        return FALSE;
+        $doRender = FALSE;
       }
-      
+
       // If there is no context, we're finished
       if (!$context) return;
 
-      // Tell context to insert form elements. Then store it, if necessary
-      $context->insertStatus($response);
-      $context->getChanged() && $request->session->putValue($cidx, $context);
+      // Tell context to insert form elements. Then store it, if a xsl will be rendered
+      if ($doRender) {
+        $context->insertStatus($response);
+      }
+
+      if ($request->session) {
+        $context->getChanged() && $request->session->putValue($cidx, $context);
+      }
+
+      return $doRender ? NULL : FALSE;
     }
 
     /**


### PR DESCRIPTION
Dont render XSL when a state returns false.
Store Context also when no XSL will be rendered (in case of redirects).
Dont call insertStatus (xml preparation for XSL template) when no xsl will be rendered.
